### PR TITLE
Fix bug involving skipping search in conditions with no winning moves

### DIFF
--- a/v2/search/mod.rs
+++ b/v2/search/mod.rs
@@ -17,10 +17,10 @@ pub fn evaluate_with_ttable(
         Evaluation::BlackWinPly(node.ply),
         Evaluation::WhiteWinPly(node.ply),
         table,
-        true,
     );
     match eval.0 {
         Some(e) => (e, eval.1),
+        // If no move is returned, just get any random result
         None => (node.get_possible_actions()[0].clone(), eval.1),
     }
 }
@@ -32,7 +32,6 @@ pub fn evaluate(node: &BreakthroughNode, depth: u32) -> (BreakthroughMove, Evalu
         Evaluation::BlackWinPly(node.ply),
         Evaluation::WhiteWinPly(node.ply),
         &mut TranspositionTable::new(0),
-        true,
     );
     match eval.0 {
         Some(e) => (e, eval.1),

--- a/v2/search/negamax.rs
+++ b/v2/search/negamax.rs
@@ -132,7 +132,6 @@ pub fn negamax(
     alpha: Evaluation,
     beta: Evaluation,
     table: &mut TranspositionTable,
-    force: bool,
 ) -> (Option<BreakthroughMove>, Evaluation) {
     if node.is_terminal() || depth == 0 {
         return (None, evaluate_result(node));
@@ -140,14 +139,12 @@ pub fn negamax(
 
     // If we don't need a move, try non-move search pruning
     // TODO we should actually store/compute the move and return it here
-    if !force {
-        if let Some(eval) = fast_win(node) {
-            return (None, eval);
-        }
+    if let Some(eval) = fast_win(node) {
+        return (None, eval);
+    }
 
-        if let Some(entry) = table.get(node, depth) {
-            return (None, entry.2);
-        }
+    if let Some(entry) = table.get(node, depth) {
+        return (None, entry.2);
     }
 
     let mut actions = get_filtered_actions(node);
@@ -171,7 +168,6 @@ pub fn negamax(
             -beta,
             -alpha,
             table,
-            false,
         );
         if -eval.1 > value.1 {
             value = (Some(action), -eval.1);


### PR DESCRIPTION
When the opponent can win in the next turn, our move generation automatically limits us to only return moves that capture the threatening piece. The workaround for this led to issues when evaluating losing positions. We remove the offending workaround (forcing move generation instead of using these heuristics), opting to simply return any legal move if evaluation returns `None`.